### PR TITLE
Makes `faulthandler` an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setup(
     license='MIT',
     py_modules=['nose_faulthandler'],
     zip_safe=False,
-    install_requires=['faulthandler'],
+    extras_require={
+        ":python_version<'3.3'": ['faulthandler'],
+    },
     entry_points={
         'nose.plugins': [
             'nose_faulthandler = nose_faulthandler:FaultHandler',


### PR DESCRIPTION
In python 3.3 and higher faulthandler is part of the standard library
which results in

`ERROR: faulthandler is a builtin module since Python 3.3`

The solution uses conditional dependency approach described here:
https://hynek.me/articles/conditional-python-dependencies/
